### PR TITLE
Don't run on title tag

### DIFF
--- a/chromoji/chrome/content.js
+++ b/chromoji/chrome/content.js
@@ -61,7 +61,7 @@ function insert() {
         }
 
         emoji.img_set = style;
-        $('*:not(iframe):not(.emoji-inner):not(style):not(script)')
+        $('*:not(iframe):not(.emoji-inner):not(style):not(script):not(title)')
             .contents()
             .filter(function () {
                 return this.nodeType === 3;


### PR DESCRIPTION
Running the script on a title tag with an emoji breaks the tag which means that Chrome will show the URL instead of the title